### PR TITLE
✨ Allow Placeholders in Selects

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -352,10 +352,14 @@
               value: ""
             }, label) : null, options.map(function (_ref, i) {
               var label = _ref.label,
-                  value = _ref.value;
+                  value = _ref.value,
+                  isPlaceholder = _ref.isPlaceholder;
               return React.createElement("option", {
                 key: i,
-                value: value
+                value: value,
+                disabled: isPlaceholder,
+                selected: isPlaceholder,
+                hidden: isPlaceholder
               }, label);
             }));
 

--- a/src/GenericFormField.jsx
+++ b/src/GenericFormField.jsx
@@ -138,8 +138,14 @@ class GenericFormField extends React.Component {
                         <option value="">{label}</option>
                         : null}
                     {
-                        options.map(({ label, value }, i) =>
-                            <option key={i} value={value}>
+                        options.map(({ label, value, isPlaceholder }, i) =>
+                            <option
+                              key={i}
+                              value={value}
+                              disabled={isPlaceholder}
+                              selected={isPlaceholder}
+                              hidden={isPlaceholder}
+                            >
                                 {label}
                             </option>
                         )


### PR DESCRIPTION
Before clicking the select:
<img width="382" alt="screenshot 2019-02-06 at 12 09 31" src="https://user-images.githubusercontent.com/6059244/52337527-2592e680-2a08-11e9-90bd-caa3b7e3f8eb.png">

Clicking (no placeholder):
<img width="414" alt="screenshot 2019-02-06 at 12 10 41" src="https://user-images.githubusercontent.com/6059244/52337555-40655b00-2a08-11e9-9e99-3f27337da9d8.png">

Just pass a props `isPlaceholder` to trigger placeholder behavior:
```options: [
            {
              label: labelTitle,
              value: '',
              isPlaceholder: true,
            },
            {
              label: miss,
              value: 'Z001',
            },
            {
              label: ms,
              value: '0001',
            },
            {
              label: mr,
              value: '0002',
            },
          ],
        },
